### PR TITLE
reverting setup-containers pip call to pip3

### DIFF
--- a/setup-containers.sh
+++ b/setup-containers.sh
@@ -9,7 +9,7 @@ docker-compose -f /opt/zapataai/docker-compose.yaml up -d
 /usr/bin/python3 --version
 which python3
 which pip3
-/usr/local/bin/pip install -r /opt/zapataai/requirements.txt
+/usr/local/bin/pip3 install -r /opt/zapataai/requirements.txt
 chmod +x /opt/zapataai/heartbeat.py
 /usr/bin/python3 /opt/zapataai/heartbeat.py 
 echo "setup-containers script completed"


### PR DESCRIPTION
Will troubleshoot this later. It seems there was an issue before as the script is logging "which pip3"